### PR TITLE
Update reference to starcoder

### DIFF
--- a/app/client/codegen.py
+++ b/app/client/codegen.py
@@ -19,9 +19,9 @@ from app.config.state import State
 config = rx.config.get_config()
 
 if config.watsonx_type == "ga":
-    # Create Starcoder chain
+    # Create CodeLlama-34b chain
     llm = WatsonxLangchainLLM(
-        model_id=ModelTypes.STARCODER.value,
+        model_id="codellama/codellama-34b-instruct-hf",
         generate_params={
             GenParams.DECODING_METHOD: "greedy",
             GenParams.MAX_NEW_TOKENS: 200,


### PR DESCRIPTION
Starcoder seems to not exist anymore, so reference is updated. See attached images.

Image below prior to updating code.
![Screenshot 2024-05-20 at 7 12 38 PM](https://github.com/nicknochnack/FullStackWatsonx/assets/21075687/e2abe8f5-8ec6-48f1-b00e-040040b46d5e)

Image below after code updated.
![Screenshot 2024-05-20 at 7 20 45 PM](https://github.com/nicknochnack/FullStackWatsonx/assets/21075687/3e6836cf-de94-4ce5-806c-46c99ea70d01)


Ideally, updates to ModelType Enum should have been done. But this was from the wml library that I couldn't directly [update](https://pypi.org/project/ibm-watson-machine-learning/). This fix should do for now..
